### PR TITLE
Add support for `--env` CLI argument.

### DIFF
--- a/bin/elasticulize
+++ b/bin/elasticulize
@@ -16,7 +16,7 @@ function loadRCFile(optionsPath) {
 const argv = minimist(process.argv.slice(2));
 const command = _.get(argv, '_[0]');
 const client = new Commands(loadRCFile());
-client._init().then(async () => {
+client._init(_.get(argv, 'env')).then(async () => {
     if (!client[command]) {
         console.log(`${command} is not a valid command`);
         return;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -14,7 +14,7 @@ function Commands (paths) {
     this.CONFIG_PATH = paths['config'];
     this.MIGRATION_PATH = paths['migrations-path'];
 
-    this._init = () => {
+    this._init = (envArgument) => {
         return new Promise(async (res, rej) => {
             if (!this.CONFIG_PATH) {
                 setImmediate(res);
@@ -32,7 +32,7 @@ function Commands (paths) {
             } else {
                 config = configData;
             }
-            this.config = _.get(config, `${env}`);
+            this.config = _.get(config, `${envArgument || env}`);
 
             // Weird bug where you cant pass https-aws-es by ref
             // Would love to remove this if someone can figure out why


### PR DESCRIPTION
Addresses #3.

Allows to supply the environment name through a `--env=NAME` CLI argument.
The documentation might need updating, if this gets merged.

Priorities of discovery are:
1. CLI `--env` argument
2. NODE_ENV environment variable
3. Fallback to `development`